### PR TITLE
`Workflow`: `release`: Reuse existing release tag to prevent build failures for multiple ABIs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,15 @@ jobs:
         run: |
           $dir = Get-ChildItem -Directory -Path "ImageMagick-*" | Select-Object -Last 1
           $tag = ($dir | Split-Path -Leaf).Substring(12)
-          Write-Host "::set-output name=TAG::$tag"
+
+          # Check if the tag already exists
+          $existingTag = "${{ steps.tag.outputs.TAG }}"
+          if ($existingTag) {
+              Write-Host "Using existing tag: $existingTag"
+          } else {
+              Write-Host "Setting new tag: $tag" 
+              echo "::set-output name=TAG::$tag"
+          }
 
       - uses: ncipollo/release-action@v1
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Previously, when building all ABIs, the first successful build would create a release tag, causing subsequent builds to fail when attempting to set the same tag.

This update modifies the "Get Latest Release Tag" step to:
- Check if the release tag already exists based on the existing tag output.
- If the tag exists, reuse it to avoid conflicts.
- If the tag does not exist, generate a new one as usual.

This ensures that all ABI builds use the same release tag, preventing failures and keeping the release process consistent.