### PR TITLE
`Workflow`: Correct matrix handling for empty ABI input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        abi: ${{ github.event.inputs.abi == 'all' && fromJson('["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]') || fromJson(format('["{0}"]', github.event.inputs.abi)) }}
+        abi: ${{ github.event.inputs.abi != '' && github.event.inputs.abi != null && fromJson(format('["{0}"]', github.event.inputs.abi)) || fromJson('["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]') }}
       fail-fast: false
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        abi: ${{ github.event.inputs.abi == 'all' && fromJson('["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]') || fromJson(format('["{0}"]', github.event.inputs.abi)) }}
+        abi: ${{ github.event.inputs.abi != '' && github.event.inputs.abi != null && fromJson(format('["{0}"]', github.event.inputs.abi)) || fromJson('["arm64-v8a", "armeabi-v7a", "x86", "x86_64"]') }}
       fail-fast: false
 
     if: |


### PR DESCRIPTION
- Fixed the matrix evaluation in the GitHub Actions workflow to correctly handle an empty or missing 'abi' input.
- When 'abi' is left empty or omitted, the workflow will now fall back to building for all ABIs (arm64-v8a, armeabi-v7a, x86, x86_64).
- Improved logic for handling manual workflow triggers (`workflow_dispatch`) and pull requests (`pull_request`).