### PR TITLE
`Woekflow`: Add support for 'molotovcherry' actor in workflow conditions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       security-events: write
 
     # right side implies it's a pull request. Run on all excpept pull requests imupdate branch
-    if: github.event_name != 'pull_request' || github.head_ref != 'imupdate' && github.actor == 'blackhat2233'
+    if: github.event_name != 'pull_request' || github.head_ref != 'imupdate' && (github.actor == 'blackhat2233' || github.actor == 'molotovcherry')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true &&
-       github.actor == 'blackhat2233' && github.head_ref == 'imupdate') ||
+       (github.actor == 'blackhat2233' || github.actor == 'molotovcherry') && github.head_ref == 'imupdate') ||
        github.event_name == 'release' || github.event_name == 'workflow_dispatch'
 
     steps:


### PR DESCRIPTION
- Include molotovcherry alongside blackhat2233 in workflow execution conditions.
- Ensure both actors can trigger workflows under the specified rules for pull requests, releases, and dispatch events.