### PR TITLE
`Workflow`: `Updater-bot`: Assign pull request reviewers dynamically …

### DIFF
--- a/.github/workflows/im-updater-bot.yml
+++ b/.github/workflows/im-updater-bot.yml
@@ -49,7 +49,8 @@ jobs:
           labels: |
             update
             automated pr
-          assignees: blackhat2233
+          assignees: |
+            ${{ github.actor == 'blackhat2233' && 'blackhat2233' || github.actor == 'molotovcherry' && 'molotovcherry' || '' }}
           draft: false
 
       - name: Check outputs


### PR DESCRIPTION
…based on GitHub actor

- Automatically assigns pull requests to 'blackhat2233' or 'molotovcherry' based on the actor who triggered the workflow.
- Ensures correct assignee is applied during pull request creation.
- Adds fallback logic to avoid assigning anyone if the actor doesn't match predefined users.