### PR TITLE
Fix ImageMagick configuration paths and version addendum formatting

### DIFF
--- a/ImageMagick-7.1.1-44/configs/arm/MagickCore/magick-baseconfig.h
+++ b/ImageMagick-7.1.1-44/configs/arm/MagickCore/magick-baseconfig.h
@@ -1115,13 +1115,13 @@
 
 /* Directory where architecture-dependent files live. */
 #ifndef MAGICKCORE_LIBRARY_ABSOLUTE_PATH
-#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7.0.8/"
+#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7/"
 #endif
 
 /* Subdirectory of lib where ImageMagick architecture dependent files are
    installed. */
 #ifndef MAGICKCORE_LIBRARY_RELATIVE_PATH
-#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7.0.8"
+#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7"
 #endif
 
 /* Binaries in libraries path base name (will be during install linked to bin)

--- a/ImageMagick-7.1.1-44/configs/arm/MagickCore/version.h
+++ b/ImageMagick-7.1.1-44/configs/arm/MagickCore/version.h
@@ -30,13 +30,13 @@ extern "C" {
 #define MagickLibVersion  0x711
 #define MagickLibVersionText  "7.1.1"
 #define MagickLibVersionNumber  10,0,2
-#define MagickLibAddendum  "'-44"
+#define MagickLibAddendum  "-44"
 #define MagickLibInterface  10
 #define MagickLibMinInterface  10
 #define MagickPlatform  "arm"
 #define MagickppLibVersionText  "7.1.1"
 #define MagickppLibVersionNumber  5:0:0
-#define MagickppLibAddendum  "'-44"
+#define MagickppLibAddendum  "-44"
 #define MagickppLibInterface  5
 #define MagickppLibMinInterface  5
 #define MagickReleaseDate  "2025-02-22"

--- a/ImageMagick-7.1.1-44/configs/arm64/MagickCore/magick-baseconfig.h
+++ b/ImageMagick-7.1.1-44/configs/arm64/MagickCore/magick-baseconfig.h
@@ -1115,13 +1115,13 @@
 
 /* Directory where architecture-dependent files live. */
 #ifndef MAGICKCORE_LIBRARY_ABSOLUTE_PATH
-#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7.0.8/"
+#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7/"
 #endif
 
 /* Subdirectory of lib where ImageMagick architecture dependent files are
    installed. */
 #ifndef MAGICKCORE_LIBRARY_RELATIVE_PATH
-#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7.0.8"
+#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7"
 #endif
 
 /* Binaries in libraries path base name (will be during install linked to bin)

--- a/ImageMagick-7.1.1-44/configs/arm64/MagickCore/version.h
+++ b/ImageMagick-7.1.1-44/configs/arm64/MagickCore/version.h
@@ -30,13 +30,13 @@ extern "C" {
 #define MagickLibVersion  0x711
 #define MagickLibVersionText  "7.1.1"
 #define MagickLibVersionNumber  10,0,2
-#define MagickLibAddendum  "'-44"
+#define MagickLibAddendum  "-44"
 #define MagickLibInterface  10
 #define MagickLibMinInterface  10
 #define MagickPlatform  "aarch64"
 #define MagickppLibVersionText  "7.1.1"
 #define MagickppLibVersionNumber  5:0:0
-#define MagickppLibAddendum  "'-44"
+#define MagickppLibAddendum  "-44"
 #define MagickppLibInterface  5
 #define MagickppLibMinInterface  5
 #define MagickReleaseDate  "2025-02-22"

--- a/ImageMagick-7.1.1-44/configs/x86-64/MagickCore/magick-baseconfig.h
+++ b/ImageMagick-7.1.1-44/configs/x86-64/MagickCore/magick-baseconfig.h
@@ -1115,13 +1115,13 @@
 
 /* Directory where architecture-dependent files live. */
 #ifndef MAGICKCORE_LIBRARY_ABSOLUTE_PATH
-#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7.0.8/"
+#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7/"
 #endif
 
 /* Subdirectory of lib where ImageMagick architecture dependent files are
    installed. */
 #ifndef MAGICKCORE_LIBRARY_RELATIVE_PATH
-#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7.0.8"
+#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7"
 #endif
 
 /* Binaries in libraries path base name (will be during install linked to bin)

--- a/ImageMagick-7.1.1-44/configs/x86-64/MagickCore/version.h
+++ b/ImageMagick-7.1.1-44/configs/x86-64/MagickCore/version.h
@@ -30,13 +30,13 @@ extern "C" {
 #define MagickLibVersion  0x711
 #define MagickLibVersionText  "7.1.1"
 #define MagickLibVersionNumber  10,0,2
-#define MagickLibAddendum  "'-44"
+#define MagickLibAddendum  "-44"
 #define MagickLibInterface  10
 #define MagickLibMinInterface  10
 #define MagickPlatform  "x86_64"
 #define MagickppLibVersionText  "7.1.1"
 #define MagickppLibVersionNumber  5:0:0
-#define MagickppLibAddendum  "'-44"
+#define MagickppLibAddendum  "-44"
 #define MagickppLibInterface  5
 #define MagickppLibMinInterface  5
 #define MagickReleaseDate  "2025-02-22"

--- a/ImageMagick-7.1.1-44/configs/x86/MagickCore/magick-baseconfig.h
+++ b/ImageMagick-7.1.1-44/configs/x86/MagickCore/magick-baseconfig.h
@@ -1115,13 +1115,13 @@
 
 /* Directory where architecture-dependent files live. */
 #ifndef MAGICKCORE_LIBRARY_ABSOLUTE_PATH
-#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7.0.8/"
+#define MAGICKCORE_LIBRARY_ABSOLUTE_PATH "/usr/local/lib/ImageMagick-7/"
 #endif
 
 /* Subdirectory of lib where ImageMagick architecture dependent files are
    installed. */
 #ifndef MAGICKCORE_LIBRARY_RELATIVE_PATH
-#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7.0.8"
+#define MAGICKCORE_LIBRARY_RELATIVE_PATH "ImageMagick-7"
 #endif
 
 /* Binaries in libraries path base name (will be during install linked to bin)

--- a/ImageMagick-7.1.1-44/configs/x86/MagickCore/version.h
+++ b/ImageMagick-7.1.1-44/configs/x86/MagickCore/version.h
@@ -30,13 +30,13 @@ extern "C" {
 #define MagickLibVersion  0x711
 #define MagickLibVersionText  "7.1.1"
 #define MagickLibVersionNumber  10,0,2
-#define MagickLibAddendum  "'-44"
+#define MagickLibAddendum  "-44"
 #define MagickLibInterface  10
 #define MagickLibMinInterface  10
 #define MagickPlatform  "x86"
 #define MagickppLibVersionText  "7.1.1"
 #define MagickppLibVersionNumber  5:0:0
-#define MagickppLibAddendum  "'-44"
+#define MagickppLibAddendum  "-44"
 #define MagickppLibInterface  5
 #define MagickppLibMinInterface  5
 #define MagickReleaseDate  "2025-02-22"


### PR DESCRIPTION
Updated MAGICKCORE_LIBRARY_ABSOLUTE_PATH and MAGICKCORE_LIBRARY_RELATIVE_PATH to remove hardcoded 7.0.8 version, replacing it with the generic ImageMagick-7 path across all architectures. Corrected MagickLibAddendum and MagickppLibAddendum by removing unnecessary single quotes around version suffix '-44'. Changes applied to configurations for arm, arm64, x86, and x86-64 architectures.