### PR TITLE
Fix NULL pointer deferenece in WriteImages function

### DIFF
--- a/ImageMagick-7.1.2-10/MagickCore/constitute.c
+++ b/ImageMagick-7.1.2-10/MagickCore/constitute.c
@@ -1541,7 +1541,13 @@ MagickExport MagickBooleanType WriteImages(const ImageInfo *image_info,
   p=images;
   for ( ; GetNextImageInList(p) != (Image *) NULL; p=GetNextImageInList(p))
   {
-    if (p->scene >= GetNextImageInList(p)->scene)
+    register Image
+      *next;
+    
+    next=GetNextImageInList(p);
+    if (next == (Image *) NULL)
+      break;
+    if (p->scene >= next->scene)
       {
         ssize_t
           i;


### PR DESCRIPTION
This PR fixes a security vulnerability in `WriteImages` that was cloned from `ImageMagick/ImageMagick` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `WriteImages` in `ImageMagick-7.1.2-10/MagickCore/constitute.c`
* **Original Fix**: https://github.com/ImageMagick/ImageMagick/commit/5b4bebaa91849c592a8448bc353ab25a54ff8c44

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the vulnerability in the cloned code.

**References:**

* https://github.com/ImageMagick/ImageMagick/commit/5b4bebaa91849c592a8448bc353ab25a54ff8c44
* https://nvd.nist.gov/vuln/detail/CVE-2015-8898

Please review and merge this PR to ensure your repository is protected against this vulnerability.