### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/libxml2-2.9.9/parser.c
+++ b/libxml2-2.9.9/parser.c
@@ -13898,6 +13898,7 @@ xmlParseBalancedChunkMemoryRecover(xmlDocPtr doc, xmlSAXHandlerPtr sax,
     xmlFreeParserCtxt(ctxt);
     newDoc->intSubset = NULL;
     newDoc->extSubset = NULL;
+    if(doc != NULL)
     newDoc->oldNs = NULL;
     xmlFreeDoc(newDoc);
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in xmlParseBalancedChunkMemoryRecover() that was cloned from https://gitlab.gnome.org/GNOME/libxml2 but did not receive the security patch.

### Details:
Affected Function: xmlParseBalancedChunkMemoryRecover() in libxml2-2.9.9/parser.c
Original Fix: https://gitlab.gnome.org/GNOME/libxml2/-/commit/5a02583c7e683896d84878bd90641d8d9b0d0549


### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://gitlab.gnome.org/GNOME/libxml2/-/commit/5a02583c7e683896d84878bd90641d8d9b0d0549
- https://nvd.nist.gov/vuln/detail/cve-2019-19956

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
