### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/ImageMagick-7.1.2-11/MagickCore/blob.c
+++ b/ImageMagick-7.1.2-11/MagickCore/blob.c
@@ -3378,7 +3378,8 @@ MagickExport MagickBooleanType OpenBlob(const ImageInfo *image_info,
       return(SetStreamBuffering(image_info,blob_info));
     }
 #if defined(MAGICKCORE_HAVE_POPEN) && defined(MAGICKCORE_PIPES_SUPPORT)
-  if (*filename == '|')
+  if ((*filename == '|') && (strchr(filename,'`') == (char *) NULL) &&
+      (strchr(filename,'"') == (char *) NULL))
     {
       char
         fileMode[MagickPathExtent],


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `OpenBlob` that was cloned from `https://github.com/ImageMagick/ImageMagick` but did not receive the security patch.

###Details:
Affected Function: `OpenBlob` n `ImageMagick-7.1.2-11/MagickCore/blob.c`
Original Fix: [https://github.com/ImageMagick/ImageMagick6/commit/58bef0396a04e07aad650d1416af6b4e11da5740]


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
- https://github.com/ImageMagick/ImageMagick6/commit/58bef0396a04e07aad650d1416af6b4e11da5740
- https://github.com/ImageMagick/ImageMagick/issues/6339
- https://github.com/advisories/GHSA-47q6-hqqr-mcr3

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
