### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/libjpeg-turbo-2.0.2/tjbench.c
+++ b/libjpeg-turbo-2.0.2/tjbench.c
@@ -166,7 +166,7 @@ int decomp(unsigned char *srcBuf, unsigned char **jpegBuf,
   }
   /* Set the destination buffer to gray so we know whether the decompressor
      attempted to write to it */
-  memset(dstBuf, 127, pitch * scaledh);
+  memset(dstBuf, 127, (size_t)pitch * scaledh);
 
   if (doYUV) {
     int width = doTile ? tilew : scaledw;
@@ -186,7 +186,7 @@ int decomp(unsigned char *srcBuf, unsigned char **jpegBuf,
     double start = getTime();
 
     for (row = 0, dstPtr = dstBuf; row < ntilesh;
-         row++, dstPtr += pitch * tileh) {
+         row++, dstPtr += (size_t)pitch * tileh) {
       for (col = 0, dstPtr2 = dstPtr; col < ntilesw;
            col++, tile++, dstPtr2 += ps * tilew) {
         int width = doTile ? min(tilew, w - col * tilew) : scaledw;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in decomp() that was cloned from https://github.com/libjpeg-turbo/libjpeg-turbo but did not receive the security patch.

### Details:
Affected Function: decomp() in libjpeg-turbo-2.0.2/tjbench.c
Original Fix: https://github.com/libjpeg-turbo/libjpeg-turbo/commit/c30b1e72dac76343ef9029833d1561de07d29bad


### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/libjpeg-turbo/libjpeg-turbo/commit/c30b1e72dac76343ef9029833d1561de07d29bad
- https://github.com/libjpeg-turbo/libjpeg-turbo/issues/388
- https://nvd.nist.gov/vuln/detail/CVE-2019-2201

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
