### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/libopenjpeg-2.3.1/src/lib/openjp2/pi.c
+++ b/libopenjpeg-2.3.1/src/lib/openjp2/pi.c
@@ -1439,7 +1439,7 @@ opj_pi_iterator_t *opj_pi_create_decode(opj_image_t *p_image,
     /* 0 < l_tcp->numlayers < 65536 c.f. opj_j2k_read_cod in j2k.c */
     l_current_pi->include = 00;
     if (l_step_l <= (UINT_MAX / (l_tcp->numlayers + 1U))) {
-        l_current_pi->include_size = (l_tcp->numlayers + 1U) * l_step_l;
+        l_current_pi->include_size = (size_t)(l_tcp->numlayers + 1U) * l_step_l;
         l_current_pi->include = (OPJ_INT16*) opj_calloc(
                                     l_current_pi->include_size, sizeof(OPJ_INT16));
     }


### PR DESCRIPTION
Hi again,

Our tool identified a potential overflow vulnerability in a clone function in `libopenjpeg-2.3.1/src/lib/openjp2/pi.c` sourced from [uclouvain/openjpeg](https://github.com/uclouvain/openjpeg). These issues, originally reported in [CVE-2016-7163](https://nvd.nist.gov/vuln/detail/CVE-2016-7163), were resolved in the repository via this commit https://github.com/uclouvain/openjpeg/commit/ef01f18dfc6780b776d0674ed3e7415c6ef54d24.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!