### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/libicu4c-64-2/common/unistr.cpp
+++ b/libicu4c-64-2/common/unistr.cpp
@@ -1563,7 +1563,11 @@ UnicodeString::doAppend(const UChar *srcChars, int32_t srcStart, int32_t srcLeng
   }
 
   int32_t oldLength = length();
-  int32_t newLength = oldLength + srcLength;
+  int32_t newLength;
+  if (uprv_add32_overflow(oldLength, srcLength, &newLength)) {
+    setToBogus();
+    return *this;
+  }
 
   // Check for append onto ourself
   const UChar* oldArray = getArrayStart();


### PR DESCRIPTION
Hi again,

Our tool identified a potential overflow vulnerability in a clone function in `libicu4c-64-2/common/unistr.cpp` sourced from [unicode-org/icu](https://github.com/unicode-org/icu). These issues, originally reported in [CVE-2020-10531](https://nvd.nist.gov/vuln/detail/CVE-2020-10531), were resolved in the repository via this commit https://github.com/unicode-org/icu/commit/b7d08bc04a4296982fcef8b6b8a354a9e4e7afca.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!