### PR TITLE
Potential fix for code scanning alert no. 186: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/libxml2-2.9.9/catalog.c
+++ b/libxml2-2.9.9/catalog.c
@@ -976,11 +976,6 @@ xmlLoadFileContent(const char *filename)
         return (NULL);
 
 #ifdef HAVE_STAT
-    if (stat(filename, &info) < 0)
-        return (NULL);
-#endif
-
-#ifdef HAVE_STAT
     if ((fd = open(filename, O_RDONLY)) < 0)
 #else
     if ((fd = fopen(filename, "rb")) == NULL)
@@ -989,6 +984,10 @@ xmlLoadFileContent(const char *filename)
         return (NULL);
     }
 #ifdef HAVE_STAT
+    if (fstat(fd, &info) < 0) {
+        close(fd);
+        return (NULL);
+    }
     size = info.st_size;
 #else
     if (fseek(fd, 0, SEEK_END) || (size = ftell(fd)) == EOF || fseek(fd, 0, SEEK_SET)) {        /* File operations denied? ok, just close and return failure */


### PR DESCRIPTION
Potential fix for [https://github.com/MolotovCherry/Android-ImageMagick7/security/code-scanning/186](https://github.com/MolotovCherry/Android-ImageMagick7/security/code-scanning/186)

In general, to fix this kind of TOCTOU issue, avoid using information derived from a pre-open `stat` on a filename to make decisions about how to use the file after it is later opened by name. Instead, either (a) perform the metadata query on the already-open file descriptor (for example, `fstat(fd, &info)`), or (b) avoid relying on precomputed metadata entirely and work with the file as a byte stream, letting the I/O operations determine the effective size.

For `xmlLoadFileContent`, the only reason `stat` is used is to obtain `st_size` so that a buffer of `size + 10` bytes can be allocated. We can remove the TOCTOU race by discarding the initial `stat` and instead obtaining the size from the open file. Since we already support a `#else` branch (when `HAVE_STAT` is not defined) that uses `fseek/ftell` on a `FILE *` to deduce the size, the safest, minimal-change fix is:

- For the `HAVE_STAT` branch, keep `open(filename, O_RDONLY)` as-is to get an `int fd`, but remove the prior `stat` call and `struct stat info`.
- After opening, call `fstat(fd, &info)` to fill in a `struct stat info` for that file descriptor, and set `size = info.st_size`. This uses the same field as before but ties it to the actual opened file, eliminating the race.
- Ensure we handle `fstat` failure by closing `fd` and returning `NULL`.

Concretely, within `xmlLoadFileContent` in libxml2-2.9.9/catalog.c:

- Remove the `struct stat info;` declaration at lines 971–972 and the `stat(filename, &info)` check at lines 978–981.
- After the `open(filename, O_RDONLY)` succeeds (line 984), insert a call to `fstat(fd, &info)` to populate `info`, and handle errors appropriately.
- Keep all existing logic for the non-`HAVE_STAT` branch unchanged.

All required headers (`<sys/types.h>`, `<sys/stat.h>`, `<fcntl.h>`, `<unistd.h>`) are already included at the top of the file, so no new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
