### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/libxml2-2.9.9/xmllint.c
+++ b/libxml2-2.9.9/xmllint.c
@@ -2201,7 +2201,7 @@ static void parseAndPrintFile(char *filename, xmlParserCtxtPtr rectxt) {
             if (res > 0) {
                 ctxt = htmlCreatePushParserCtxt(NULL, NULL,
                             chars, res, filename, XML_CHAR_ENCODING_NONE);
-                xmlCtxtUseOptions(ctxt, options);
+                htmlCtxtUseOptions(ctxt, options);
                 while ((res = fread(chars, 1, pushsize, f)) > 0) {
                     htmlParseChunk(ctxt, chars, res, 0);
                 }


### PR DESCRIPTION
Hi Development team,

Our tool identified a potential use-after-free vulnerability in a clone function in `parseAndPrintFile()` in `libxml2-2.9.9/xmllint.c` sourced from [GNOME/libxml2](https://github.com/GNOME/libxml2). These issues, originally reported in [CVE-2021-3516](https://nvd.nist.gov/vuln/detail/CVE-2021-3516), were resolved in the repository via this commit https://github.com/GNOME/libxml2/commit/1358d157d0bd83be1dfe356a69213df9fac0b539.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!