### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/ImageMagick-7.1.2-15/MagickCore/blob.c
+++ b/ImageMagick-7.1.2-15/MagickCore/blob.c
@@ -3378,7 +3378,8 @@ MagickExport MagickBooleanType OpenBlob(const ImageInfo *image_info,
       return(SetStreamBuffering(image_info,blob_info));
     }
 #if defined(MAGICKCORE_HAVE_POPEN) && defined(MAGICKCORE_PIPES_SUPPORT)
-  if (*filename == '|')
+  if ((*filename == '|') && (strchr(filename,'`') == (char *) NULL) &&
+      (strchr(filename,'"') == (char *) NULL))
     {
       char
         fileMode[MagickPathExtent],


### PR DESCRIPTION
Hi Development Team,

Our tool identified a potential vulnerability in clone functions in `ImageMagick-7.1.2-15/MagickCore/blob.c` sourced from [ImageMagick/ImageMagick](https://github.com/ImageMagick/ImageMagick). These issues, originally reported in [CVE-2023-34152](https://nvd.nist.gov/vuln/detail/CVE-2023-34152), were resolved in the repository via this commit https://github.com/ImageMagick/ImageMagick/commit/17c4859bf4b1551185ab0b296e61b60b13969917.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.